### PR TITLE
feat: use html5-qrcode for cross-browser scanning

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,51 +4,21 @@
   <meta charset="UTF-8">
   <title>Barcode Scanner POC</title>
   <style>
-    #video {
-      width: 320px;
-      height: 240px;
-      border: 1px solid #ccc;
+    #reader {
+      width: 300px;
     }
   </style>
 </head>
 <body>
   <h1>Barcode Scanner POC</h1>
   <input id="barcode" type="text" placeholder="Scanned code will appear here" />
-  <button id="start-scan">Start Scan</button>
-  <video id="video" autoplay muted playsinline></video>
+  <div id="reader"></div>
+  <div id="result"></div>
+  <script src="https://unpkg.com/html5-qrcode"></script>
+  <script src="scanner.js"></script>
   <script>
-    const startBtn = document.getElementById('start-scan');
-    const barcodeInput = document.getElementById('barcode');
-    const video = document.getElementById('video');
-
-    async function startScan() {
-      if (!('BarcodeDetector' in window)) {
-        alert('Barcode Detector not supported on this browser');
-        return;
-      }
-      const detector = new BarcodeDetector({ formats: ['code_128', 'ean_13', 'ean_8', 'upc_a', 'upc_e'] });
-      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
-      video.srcObject = stream;
-      const track = stream.getVideoTracks()[0];
-      const scan = async () => {
-        if (video.readyState === video.HAVE_ENOUGH_DATA) {
-          try {
-            const barcodes = await detector.detect(video);
-            if (barcodes.length > 0) {
-              barcodeInput.value = barcodes[0].rawValue;
-              track.stop();
-              return;
-            }
-          } catch (err) {
-            console.error('Detection error', err);
-          }
-        }
-        requestAnimationFrame(scan);
-      };
-      scan();
-    }
-
-    startBtn.addEventListener('click', startScan);
+    scanner.requestCameraPermission();
+    scanner.startScanner();
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests specified\"",
+    "test": "node test.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/scanner.js
+++ b/scanner.js
@@ -1,0 +1,45 @@
+(function(global) {
+  let Html5QrcodeScanner;
+  if (typeof window === 'undefined') {
+    Html5QrcodeScanner = require('html5-qrcode').Html5QrcodeScanner;
+  } else {
+    Html5QrcodeScanner = global.Html5QrcodeScanner;
+  }
+
+  function onScanSuccess(decodedText, decodedResult, scanner) {
+    document.getElementById('barcode').value = decodedText;
+    document.getElementById('result').innerText = `Scanned: ${decodedText}`;
+    return scanner.clear().then(() => {
+      console.log('Scanner stopped.');
+    });
+  }
+
+  function onScanFailure(error) {
+    // Optional: console.warn(`Scan error: ${error}`);
+  }
+
+  function requestCameraPermission(navigatorRef = navigator) {
+    return navigatorRef.mediaDevices.getUserMedia({ video: true })
+      .then(stream => stream.getTracks().forEach(track => track.stop()))
+      .catch(err => console.error('Camera permission denied', err));
+  }
+
+  function startScanner() {
+    const scanner = new Html5QrcodeScanner('reader', {
+      fps: 10,
+      qrbox: 250,
+      rememberLastUsedCamera: true,
+      supportedScanTypes: [Html5QrcodeScanner.SCAN_TYPE_CAMERA, Html5QrcodeScanner.SCAN_TYPE_FILE]
+    }, false);
+    scanner.render((text, result) => onScanSuccess(text, result, scanner), onScanFailure);
+    return scanner;
+  }
+
+  const api = { startScanner, onScanSuccess, onScanFailure, requestCameraPermission };
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.scanner = api;
+  }
+})(typeof window !== 'undefined' ? window : global);
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+
+class MockHtml5QrcodeScanner {
+  constructor(id, options, verbose) {
+    this.id = id;
+    this.options = options;
+    this.verbose = verbose;
+    this.renderCalled = false;
+    this.clearCalled = false;
+  }
+  render(success, failure) {
+    this.renderCalled = true;
+    this.successCallback = success;
+    this.failureCallback = failure;
+  }
+  clear() {
+    this.clearCalled = true;
+    return Promise.resolve();
+  }
+}
+
+// Set up global window with stubbed Html5QrcodeScanner
+global.window = { Html5QrcodeScanner: MockHtml5QrcodeScanner };
+window.Html5QrcodeScanner.SCAN_TYPE_CAMERA = 'camera';
+window.Html5QrcodeScanner.SCAN_TYPE_FILE = 'file';
+
+// Minimal DOM implementation
+const document = {
+  elements: {},
+  getElementById(id) {
+    return this.elements[id];
+  }
+};
+
+global.document = document;
+
+document.elements['barcode'] = { value: '' };
+// reader element needed but not used directly
+document.elements['reader'] = {};
+
+document.elements['result'] = { innerText: '' };
+
+const { startScanner, onScanSuccess, requestCameraPermission } = require('./scanner');
+
+async function testStartScanner() {
+  const scanner = startScanner();
+  assert.strictEqual(scanner.id, 'reader');
+  assert.deepStrictEqual(scanner.options, {
+    fps: 10,
+    qrbox: 250,
+    rememberLastUsedCamera: true,
+    supportedScanTypes: ['camera', 'file']
+  });
+  assert.strictEqual(scanner.verbose, false);
+  assert.ok(scanner.renderCalled, 'render should be called');
+}
+
+async function testOnScanSuccess() {
+  const scanner = new MockHtml5QrcodeScanner();
+  await onScanSuccess('12345', {}, scanner);
+  assert.strictEqual(document.getElementById('barcode').value, '12345');
+  assert.strictEqual(document.getElementById('result').innerText, 'Scanned: 12345');
+  assert.ok(scanner.clearCalled, 'clear should be called');
+}
+
+async function testRequestCameraPermission() {
+  let stopCalled = false;
+  const fakeNavigator = {
+    mediaDevices: {
+      getUserMedia: () => Promise.resolve({
+        getTracks: () => [{ stop: () => { stopCalled = true; } }]
+      })
+    }
+  };
+  await requestCameraPermission(fakeNavigator);
+  assert.ok(stopCalled, 'track.stop should be called');
+}
+
+(async function runTests() {
+  try {
+    await testStartScanner();
+    await testOnScanSuccess();
+    await testRequestCameraPermission();
+    console.log('All tests passed');
+  } catch (err) {
+    console.error('Test failed:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- refactor scanner into a reusable module that initializes Html5Qrcode and requests camera permission
- add a lightweight Node-based test harness covering initialization, scan success handling, and camera permission flow

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68912982fd248323be56215954d4d9fc